### PR TITLE
Add Compact Variant implementation

### DIFF
--- a/internal/cvariant/doc.go
+++ b/internal/cvariant/doc.go
@@ -1,0 +1,12 @@
+/*
+Package cvariant implements a more compact Variant data type.
+
+Compared to Variant type found in the "variant" package "cvariant"
+implementation trades a small amount of speed for 8 byte reduction of
+space per Variant on 64 bits systems. The implementation currently targets amd64 GOARCH
+only (it can be extended to other architectures).
+
+On 64 bit systems the size of Variant is 16 bytes for primitive types such as int or
+float64.
+*/
+package cvariant

--- a/internal/cvariant/variant.go
+++ b/internal/cvariant/variant.go
@@ -1,0 +1,340 @@
+// +build amd64
+
+package cvariant
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"unsafe"
+)
+
+// Type of a value stored in Variant.
+type VType int
+
+// Possible value types that can be stored in Variant.
+const (
+	// Empty or no value. The default state of zero-initialized Variant.
+	VTypeEmpty VType = iota
+
+	// An int number.
+	VTypeInt
+
+	// A float64 number.
+	VTypeFloat64
+
+	// A string.
+	VTypeString
+
+	// A []byte slice.
+	VTypeBytes
+
+	// A list of Variant.
+	VTypeValueList
+
+	// A list of KeyValue.
+	VTypeKeyValueList
+)
+
+// Number of bits to use for Type field. This should be wide enough to fit all VType values.
+const TypeFieldBitCount = 3
+
+const totalBitCount = 8 * unsafe.Sizeof(int64(0))
+const lenAndCapBitCount = totalBitCount - TypeFieldBitCount
+
+const capFieldBitCount = lenAndCapBitCount / 2
+const capFieldShiftCount = TypeFieldBitCount
+const capFieldMask = (1 << capFieldBitCount) - 1
+
+const lenFieldBitCount = lenAndCapBitCount - capFieldBitCount
+const lenFieldShiftCount = TypeFieldBitCount + capFieldBitCount
+const lenFieldMask = (1 << lenFieldBitCount) - 1
+
+// Bit mask for Type part of lenAndType field.
+const typeFieldMask = (1 << TypeFieldBitCount) - 1
+
+//const lenFieldShiftCount = TypeFieldBitCount
+
+// Maximum length of a slice-type that can be stored in Variant. The length of Go slices
+// can be at most maxint, however Variant is not able to store lengths of maxint. Len field
+// in Variant uses lenFieldShiftCount bits less than int, i.e. the maximum length of a slice
+// stored in Variant is maxint / (2^lenFieldShiftCount), which we calculate below.
+const MaxSliceLen = int((^uint(0))>>1) >> lenFieldShiftCount
+
+// A slice of VType values which is used as a marker of the type to which the Variant's
+// ptr field points to for non pointer types.
+var intTypeMarker = VTypeInt
+var floatTypeMarker = VTypeFloat64
+
+// KeyValue is an element that is used for VTypeKeyValueList storage.
+type KeyValue struct {
+	Key   string
+	Value Variant
+}
+
+// Type returns the type of the currently stored value.
+func (v *Variant) Type() VType {
+	if v.ptr != nil {
+		switch v.ptr {
+		case unsafe.Pointer(&intTypeMarker):
+			return VTypeInt
+		case unsafe.Pointer(&floatTypeMarker):
+			return VTypeFloat64
+		}
+	}
+
+	return VType(v.bits & typeFieldMask)
+}
+
+// NewEmpty creates a Variant of VTypeEmpty type.
+func NewEmpty() Variant {
+	return Variant{}
+}
+
+// NewString creates a Variant of VTypeString type.
+func NewString(v string) Variant {
+	hdr := (*reflect.StringHeader)(unsafe.Pointer(&v))
+	if hdr.Len > MaxSliceLen {
+		panic("maximum len exceeded")
+	}
+
+	return Variant{
+		ptr:  unsafe.Pointer(hdr.Data),
+		bits: uint(hdr.Len<<lenFieldShiftCount) | uint(VTypeString),
+	}
+}
+
+// NewStringFromBytes creates a Variant of VTypeString type from a slice of bytes
+// that represent the string.
+//
+// WARNING: the string stored inside this Variant will be aliased in the memory and will
+// share its storage with the byte slice provided. This means any changes to the bytes
+// in the slice will also modify the string in this Variant.
+//
+// This function should be only used when it is guaranteed that the bytes
+// in the slice will not be modified or when the immutability of the string
+// stored inside this Variant is not required. In such cases NewStringFromBytes(v)
+// provides significant performance advantage over NewString(string(v)) call,
+// which will create a copy of byte slice 'v'.
+func NewStringFromBytes(v []byte) (r Variant) {
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+	if hdr.Len > MaxSliceLen {
+		panic("maximum len exceeded")
+	}
+
+	return Variant{
+		ptr:  unsafe.Pointer(hdr.Data),
+		bits: uint(hdr.Len<<lenFieldShiftCount) | uint(VTypeString),
+	}
+}
+
+// IntVal returns the stored int value.
+// The returned value is undefined if the Variant type is not VTypeInt.
+func (v *Variant) IntVal() int {
+	return int(v.bits)
+}
+
+// Float64Val returns the stored float64 value.
+// The returned value is undefined if the Variant type is not VTypeFloat64.
+func (v *Variant) Float64Val() float64 {
+	return *(*float64)(unsafe.Pointer(&v.bits))
+}
+
+// StringVal returns the stored string value.
+// Will panic if the Variant type is not VTypeString.
+func (v *Variant) StringVal() (s string) {
+	switch v.ptr {
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeString")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeString {
+		panic("Variant is not a VTypeString")
+	}
+
+	dest := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	dest.Data = uintptr(v.ptr)
+	dest.Len = int(v.bits >> lenFieldShiftCount)
+	return s
+}
+
+// Bytes returns the stored byte slice.
+// Will panic if the Variant type is not VTypeBytes.
+func (v *Variant) Bytes() (b []byte) {
+	switch v.ptr {
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeBytes")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeBytes {
+		panic("Variant is not a VTypeBytes")
+	}
+
+	dest := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	dest.Data = uintptr(v.ptr)
+	dest.Len = int(v.bits >> lenFieldShiftCount)
+	dest.Cap = int((v.bits >> capFieldShiftCount) & capFieldMask)
+	return b
+}
+
+// ValueList returns the slice of stored Variant values.
+// Elements in the returned slice are allowed to be modified after this call returns.
+// Will panic if the Variant type is not VTypeValueList.
+func (v *Variant) ValueList() (s []Variant) {
+	switch v.ptr {
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeValueList")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeValueList {
+		panic("Variant is not a VTypeValueList")
+	}
+
+	dest := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	dest.Data = uintptr(v.ptr)
+	dest.Len = int(v.bits >> lenFieldShiftCount)
+	dest.Cap = int((v.bits >> capFieldShiftCount) & capFieldMask)
+	return s
+}
+
+// ValueAt returns the value at the specified index.
+//
+// Valid to call only if Variant type is VTypeValueList otherwise will panic.
+// Will panic if index is negative or is greater or equal the current length.
+func (v *Variant) ValueAt(index int) Variant {
+	switch v.ptr {
+	case nil:
+		fallthrough
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeValueList or is empty")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeValueList {
+		panic("Variant is not a VTypeValueList")
+	}
+
+	if index < 0 || index >= v.Len() {
+		panic("index out of bounds")
+	}
+
+	return *(*Variant)(unsafe.Pointer(uintptr(v.ptr) + uintptr(index)*unsafe.Sizeof(Variant{})))
+}
+
+// Len returns the length of contained slice-based type.
+// Valid to call for VTypeString, VTypeBytes, VTypeValueList, VTypeKeyValueList types.
+// For other types the returned value is undefined.
+func (v *Variant) Len() int {
+	return int(v.bits >> lenFieldShiftCount)
+}
+
+// Resize the length of contained slice-based type.
+// Valid to call for VTypeString, VTypeBytes, VTypeValueList, VTypeKeyValueList types.
+// Will panic for other types.
+// Will panic if len is negative or exceeds the current capacity of the slice or if
+// len exceeds MaxSliceLen.
+func (v *Variant) Resize(len int) {
+	switch v.Type() {
+	case VTypeEmpty, VTypeInt, VTypeFloat64:
+		panic(fmt.Sprintf("Cannot resize Variant type %d", v.Type()))
+	}
+
+	if len < 0 {
+		panic("negative len is not allowed")
+	}
+	if len > int((v.bits>>capFieldShiftCount)&capFieldMask) {
+		panic("cannot resize beyond capacity")
+	}
+	if len > MaxSliceLen {
+		panic("maximum len exceeded")
+	}
+	v.bits = (v.bits & (typeFieldMask | (capFieldMask << capFieldShiftCount))) | (uint(len) << lenFieldShiftCount)
+}
+
+// KeyValueList return the slice of stored KeyValue.
+// Valid to call only if Type==VTypeKeyValueList otherwise will panic.
+// Elements in the returned slice are allowed to be modified after this call returns.
+// Such modification will affect the KeyValue stored in this Variant since returned
+// slice is a reference type.
+func (v *Variant) KeyValueList() (s []KeyValue) {
+	switch v.ptr {
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeKeyValueList")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeKeyValueList {
+		panic("Variant is not a VTypeKeyValueList")
+	}
+
+	dest := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	dest.Data = uintptr(v.ptr)
+	dest.Len = int(v.bits >> lenFieldShiftCount)
+	dest.Cap = int((v.bits >> capFieldShiftCount) & capFieldMask)
+	return s
+}
+
+// KeyValueAt returns the KeyValue at the specified index.
+//
+// Valid to call only if Variant type is VTypeKeyValueList otherwise will panic.
+// The element is returned by pointer to allow the caller to modify the element
+// by assigning to it if needed.
+// Will panic if index is negative or is greater or equal the current length.
+func (v *Variant) KeyValueAt(index int) *KeyValue {
+	switch v.ptr {
+	case nil:
+		fallthrough
+	case unsafe.Pointer(&intTypeMarker):
+		fallthrough
+	case unsafe.Pointer(&floatTypeMarker):
+		panic("Variant is not a VTypeKeyValueList or is empty")
+	}
+
+	if VType(v.bits&typeFieldMask) != VTypeKeyValueList {
+		panic("Variant is not a VTypeKeyValueList")
+	}
+
+	if index < 0 || index >= v.Len() {
+		panic("index out of bounds")
+	}
+
+	return (*KeyValue)(unsafe.Pointer(uintptr(v.ptr) + uintptr(index)*unsafe.Sizeof(KeyValue{})))
+}
+
+// String returns a human readable string representation of the stored value.
+func (v Variant) String() string {
+	switch v.Type() {
+	case VTypeEmpty:
+		return ""
+	case VTypeInt:
+		return strconv.Itoa(v.IntVal())
+	case VTypeFloat64:
+		return strconv.FormatFloat(v.Float64Val(), 'g', -1, 64)
+	case VTypeString:
+		return fmt.Sprintf("%q", v.StringVal())
+	case VTypeBytes:
+		return fmt.Sprintf("0x%X", v.Bytes())
+	case VTypeValueList:
+		var strs []string
+		for _, e := range v.ValueList() {
+			strs = append(strs, e.String())
+		}
+		return "[" + strings.Join(strs, ",") + "]"
+	case VTypeKeyValueList:
+		var strs []string
+		for _, e := range v.KeyValueList() {
+			strs = append(strs, fmt.Sprintf("%q:%s", e.Key, e.Value.String()))
+		}
+		return "{" + strings.Join(strs, ",") + "}"
+	}
+	panic("invalid Variant type")
+}

--- a/internal/cvariant/variant_64.go
+++ b/internal/cvariant/variant_64.go
@@ -1,0 +1,84 @@
+// +build amd64
+
+package cvariant
+
+// This file contains Variant implementation specific to GOARCH=amd64
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+type Variant struct {
+	// Pointer to the slice start for slice-based types.
+	ptr unsafe.Pointer
+
+	bits uint
+}
+
+// NewInt creates a Variant of VTypeInt type.
+func NewInt(v int) Variant {
+	return Variant{
+		ptr:  unsafe.Pointer(&intTypeMarker),
+		bits: uint(v),
+	}
+}
+
+// NewFloat64 creates a Variant of VTypeFloat64 type.
+func NewFloat64(v float64) Variant {
+	return Variant{
+		ptr:  unsafe.Pointer(&floatTypeMarker),
+		bits: *(*uint)(unsafe.Pointer(&v)),
+	}
+}
+
+// NewBytes creates a Variant of VTypeBytes type and initializes it with the specified
+// slice of bytes.
+//
+// This function does not copy the slice. The Variant will point to
+// the same slice that is pointed to by the parameter v. Any changes made to the bytes
+// in the slice v will be also reflected in the byte slice stored in this Variant.
+func NewBytes(v []byte) Variant {
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+	if hdr.Len > MaxSliceLen {
+		panic("maximum len exceeded")
+	}
+
+	return Variant{
+		ptr:  unsafe.Pointer(hdr.Data),
+		bits: uint(hdr.Len<<lenFieldShiftCount) | uint(hdr.Cap<<capFieldShiftCount) | uint(VTypeBytes),
+	}
+}
+
+// NewValueList creates a Variant of VTypeValueList type and initializes it with the
+// specified slice of Variants.
+//
+// This function does not copy the slice. The Variant will point to the same slice that
+// is pointed to by the parameter v. Any changes made to the elements in the slice v
+// will be also reflected in the list stored in this Variant.
+func NewValueList(v []Variant) Variant {
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+	if hdr.Len > MaxSliceLen {
+		panic("maximum len exceeded")
+	}
+
+	return Variant{
+		ptr:  unsafe.Pointer(hdr.Data),
+		bits: uint(hdr.Len<<lenFieldShiftCount) | uint(hdr.Cap<<capFieldShiftCount) | uint(VTypeValueList),
+	}
+}
+
+// NewKeyValueList creates a Variant of VTypeKeyValueList type and initializes it with the
+// specified slice of KeyValues.
+//
+// This function does not copy the slice. The Variant will point to the same slice that
+// is pointed to by the parameter v. Any changes made to the elements in the slice v
+// will be also reflected in the list stored in this Variant.
+func NewKeyValueList(v []KeyValue) Variant {
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+
+	return Variant{
+		ptr:  unsafe.Pointer(hdr.Data),
+		bits: uint(hdr.Len<<lenFieldShiftCount) | uint(hdr.Cap<<capFieldShiftCount) | uint(VTypeKeyValueList),
+	}
+}

--- a/internal/cvariant/variant_64_test.go
+++ b/internal/cvariant/variant_64_test.go
@@ -1,0 +1,17 @@
+// +build amd64
+
+package cvariant
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVariantFloat64FieldStorage(t *testing.T) {
+	v := Variant{}
+
+	// Ensure float64 can correctly fit in bits
+	assert.EqualValues(t, unsafe.Sizeof(float64(0.0)), unsafe.Sizeof(v.bits))
+}

--- a/internal/cvariant/variant_test.go
+++ b/internal/cvariant/variant_test.go
@@ -1,0 +1,538 @@
+// +build amd64
+
+package cvariant
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tigrannajaryan/govariant/internal/testutil"
+)
+
+func ExampleCreateVariant() {
+	v := NewInt(123)
+	if v.Type() == VTypeInt {
+		fmt.Print(v.IntVal())
+	}
+
+	// Output: 123
+}
+
+func TestVariantFieldAliasing(t *testing.T) {
+	v := Variant{}
+
+	// Ensure fields correctly alias corresponding fields of StringHeader
+
+	// Data/ptr field.
+	assert.EqualValues(t, unsafe.Sizeof(reflect.StringHeader{}.Data), unsafe.Sizeof(v.ptr))
+
+	// Ensure fields correctly alias corresponding fields of SliceHeader
+
+	// Data/ptr field.
+	assert.EqualValues(t, unsafe.Sizeof(reflect.SliceHeader{}.Data), unsafe.Sizeof(v.ptr))
+
+	// Ensure float64 can correctly fit in capOrVal
+	assert.EqualValues(t, unsafe.Sizeof(float64(0.0)), unsafe.Sizeof(v.bits))
+}
+
+func TestVariant(t *testing.T) {
+	fmt.Printf("Variant size=%v bytes\n", unsafe.Sizeof(Variant{}))
+
+	v := NewEmpty()
+	assert.EqualValues(t, VTypeEmpty, v.Type())
+	assert.EqualValues(t, "", v.String())
+
+	b1 := []byte{1, 2, 0xA}
+	v = NewBytes(b1)
+	b2 := v.Bytes()
+	assert.EqualValues(t, b1, b2)
+	assert.EqualValues(t, VTypeBytes, v.Type())
+	//assert.EqualValues(t, "0x01020A", v.String())
+
+	s1 := "abcdef"
+	v = NewString(s1)
+	s2 := v.StringVal()
+	assert.EqualValues(t, s1, s2)
+	assert.EqualValues(t, VTypeString, v.Type())
+	assert.EqualValues(t, `"abcdef"`, v.String())
+
+	i1 := 1234
+	v = NewInt(i1)
+	i2 := v.IntVal()
+	assert.EqualValues(t, i1, i2)
+	assert.EqualValues(t, VTypeInt, v.Type())
+	assert.EqualValues(t, "1234", v.String())
+
+	f1 := 1234.567
+	v = NewFloat64(f1)
+	f2 := v.Float64Val()
+	assert.EqualValues(t, f1, f2)
+	assert.EqualValues(t, VTypeFloat64, v.Type())
+	assert.EqualValues(t, "1234.567", v.String())
+}
+
+func TestVariantValueList(t *testing.T) {
+	v := NewValueList(nil)
+	assert.EqualValues(t, VTypeValueList, v.Type())
+	assert.EqualValues(t, 0, v.Len())
+	assert.EqualValues(t, []Variant(nil), v.ValueList())
+	assert.EqualValues(t, "[]", v.String())
+	assert.Panics(t, func() { v.ValueAt(0) }, "should panic on nil slice")
+
+	v = NewValueList([]Variant{NewInt(123), NewString("abc")})
+	assert.EqualValues(t, 2, v.Len())
+	assert.EqualValues(t, []Variant{NewInt(123), NewString("abc")}, v.ValueList())
+	assert.EqualValues(t, NewInt(123), v.ValueAt(0))
+	assert.EqualValues(t, NewString("abc"), v.ValueAt(1))
+	assert.EqualValues(t, `[123,"abc"]`, v.String())
+	assert.Panics(t, func() { v.ValueAt(-1) }, "should panic on negative index")
+	assert.Panics(t, func() { v.ValueAt(2) }, "should panic on out of bounds")
+}
+
+func TestVariantKeyValueList(t *testing.T) {
+	var nilKvl []KeyValue
+	v := NewKeyValueList(nilKvl)
+	assert.EqualValues(t, VTypeKeyValueList, v.Type())
+	assert.EqualValues(t, 0, v.Len())
+	assert.EqualValues(t, nilKvl, v.KeyValueList())
+	assert.EqualValues(t, "{}", v.String())
+	assert.Panics(t, func() { v.KeyValueAt(0) }, "should panic on nil slice")
+
+	v = NewKeyValueList(make([]KeyValue, 0, 2))
+	assert.EqualValues(t, 0, v.Len())
+	assert.EqualValues(t, "{}", v.String())
+	assert.Panics(t, func() { v.KeyValueAt(1) })
+
+	v.Resize(2)
+	assert.EqualValues(t, 2, v.Len())
+	assert.EqualValues(t, []KeyValue{{}, {}}, v.KeyValueList())
+	assert.EqualValues(t, `{"":,"":}`, v.String())
+	assert.Panics(t, func() { v.KeyValueAt(-1) }, "should panic on negative index")
+	assert.Panics(t, func() { v.KeyValueAt(3) }, "should panic on out of bounds")
+
+	kv := v.KeyValueAt(0)
+	assert.NotNil(t, kv)
+	kv.Key = "key1"
+	kv.Value = NewString("value1")
+	assert.EqualValues(t, `{"key1":"value1","":}`, v.String())
+
+	kv = v.KeyValueAt(1)
+	assert.NotNil(t, kv)
+	kv.Key = `key2"`
+	kv.Value = NewFloat64(1.23)
+	assert.EqualValues(t, `{"key1":"value1","key2\"":1.23}`, v.String())
+
+	kv = v.KeyValueAt(0)
+	assert.NotNil(t, kv)
+	assert.EqualValues(t, "key1", kv.Key)
+	assert.EqualValues(t, "value1", kv.Value.StringVal())
+
+	kv = v.KeyValueAt(1)
+	assert.NotNil(t, kv)
+	assert.EqualValues(t, `key2"`, kv.Key)
+	assert.EqualValues(t, 1.23, kv.Value.Float64Val())
+
+	list := v.KeyValueList()
+	assert.EqualValues(t, "key1", list[0].Key)
+	assert.EqualValues(t, "value1", list[0].Value.StringVal())
+	assert.EqualValues(t, `key2"`, list[1].Key)
+	assert.EqualValues(t, 1.23, list[1].Value.Float64Val())
+
+	// Update an element.
+	list[0] = KeyValue{"newKey", NewInt(123)}
+
+	// Verify that it updated correctly.
+	list = v.KeyValueList()
+	assert.EqualValues(t, "newKey", list[0].Key)
+	assert.EqualValues(t, 123, list[0].Value.IntVal())
+	assert.EqualValues(t, `{"newKey":123,"key2\"":1.23}`, v.String())
+}
+
+func TestVariantGC(t *testing.T) {
+
+	var bb []*Variant
+
+	var v1 Variant
+	s1 := strconv.Itoa(1234)
+	v1 = NewString(s1)
+	v1 = v1
+
+	for i := 0; i < 10000; i++ {
+		s1 := strconv.Itoa(i)
+		vi := new(Variant)
+		*vi = NewString(s1)
+		b := vi
+		bb = append(bb, b)
+	}
+
+	var v Variant
+	s1 = strconv.Itoa(1234)
+	v = NewString(s1)
+
+	s2 := v.StringVal()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	bb = nil
+
+	runtime.GC()
+
+	runtime.ReadMemStats(&ms)
+
+	s2 = v.StringVal()
+	s2 = s2
+}
+
+func TestVariantPanics(t *testing.T) {
+	vals := []Variant{
+		NewEmpty(),
+		NewInt(123),
+		NewFloat64(1.23),
+	}
+	for _, v := range vals {
+		t.Run(v.String(), func(t *testing.T) {
+			// Check that get value of the type that is not what the function expects panics.
+			assert.Panics(t, func() { v.StringVal() })
+			assert.Panics(t, func() { v.Bytes() })
+			assert.Panics(t, func() { v.ValueList() })
+			assert.Panics(t, func() { v.ValueAt(0) })
+			assert.Panics(t, func() { v.Resize(1) })
+			assert.Panics(t, func() { v.KeyValueList() })
+			assert.Panics(t, func() { v.KeyValueAt(0) })
+		})
+	}
+}
+
+func TestResize(t *testing.T) {
+	v := NewBytes([]byte("abc"))
+	assert.EqualValues(t, 3, v.Len())
+	assert.EqualValues(t, []byte("abc"), v.Bytes())
+
+	v.Resize(2)
+	assert.EqualValues(t, 2, v.Len())
+	assert.EqualValues(t, []byte("ab"), v.Bytes())
+
+	v.Resize(3)
+	assert.EqualValues(t, 3, v.Len())
+	assert.EqualValues(t, []byte("abc"), v.Bytes())
+
+	assert.Panics(t, func() { v.Resize(-1) })
+	assert.Panics(t, func() { v.Resize(4) })
+}
+
+func createVariantInt() Variant {
+	for i := 0; i < 1; i++ {
+		return NewInt(testutil.IntMagicVal)
+	}
+	return NewInt(testutil.IntMagicVal)
+}
+
+func createVariantFloat64() Variant {
+	for i := 0; i < 1; i++ {
+		return NewFloat64(testutil.Float64MagicVal)
+	}
+	return NewFloat64(0)
+}
+
+func createVariantString() Variant {
+	for i := 0; i < 1; i++ {
+		return NewString(testutil.StrMagicVal)
+	}
+	return NewString("def")
+}
+
+func createVariantBytes() Variant {
+	for i := 0; i < 1; i++ {
+		return NewBytes(testutil.BytesMagicVal)
+	}
+	return NewBytes(testutil.BytesMagicVal)
+}
+
+func BenchmarkVariantIntGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		v := createVariantInt()
+		vi := v.IntVal()
+		if vi != testutil.IntMagicVal {
+			panic("invalid value")
+		}
+	}
+}
+
+func BenchmarkVariantFloat64Get(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		v := createVariantFloat64()
+		vf := v.Float64Val()
+		if vf != testutil.Float64MagicVal {
+			panic("invalid value")
+		}
+	}
+}
+
+func BenchmarkVariantIntTypeAndGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		v := createVariantInt()
+		if v.Type() == VTypeInt {
+			vi := v.IntVal()
+			if vi != testutil.IntMagicVal {
+				panic("invalid value")
+			}
+		} else {
+			panic("invalid type")
+		}
+	}
+}
+
+func BenchmarkVariantStringTypeAndGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		v := createVariantString()
+		if v.Type() == VTypeString {
+			if v.StringVal() == "" {
+				panic("empty string")
+			}
+		} else {
+			panic("invalid type")
+		}
+	}
+}
+
+func BenchmarkVariantBytesTypeAndGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		v := createVariantBytes()
+		if v.Type() == VTypeBytes {
+			if v.Bytes() == nil {
+				panic("nil bytes")
+			}
+		} else {
+			panic("invalid type")
+		}
+	}
+}
+
+func createVariantIntSlice(n int) []Variant {
+	v := make([]Variant, n)
+	for i := 0; i < n; i++ {
+		v[i] = NewInt(i)
+	}
+	return v
+}
+
+func createVariantStringSlice(n int) []Variant {
+	v := make([]Variant, n)
+	for i := 0; i < n; i++ {
+		v[i] = NewString("abc")
+	}
+	return v
+}
+
+func BenchmarkVariantIntSliceGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := createVariantIntSlice(testutil.VariantListSize)
+		for _, v := range vv {
+			if v.IntVal() < 0 {
+				panic("zero int")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantIntSliceTypeAndGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := createVariantIntSlice(testutil.VariantListSize)
+		for _, v := range vv {
+			if v.Type() == VTypeInt {
+				if v.IntVal() < 0 {
+					panic("zero int")
+				}
+			} else {
+				panic("invalid type")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantStringSliceTypeAndGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := createVariantStringSlice(testutil.VariantListSize)
+		for _, v := range vv {
+			if v.Type() == VTypeString {
+				if v.StringVal() == "" {
+					panic("empty string")
+				}
+			} else {
+				panic("invalid type")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantStringSliceGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := createVariantStringSlice(testutil.VariantListSize)
+		for _, v := range vv {
+			if v.StringVal() == "" {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantValueListGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := NewValueList(createVariantStringSlice(testutil.VariantListSize))
+		for _, v := range vv.ValueList() {
+			if v.StringVal() == "" {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantValueListForRangeAll(b *testing.B) {
+	vv := NewValueList(createVariantStringSlice(testutil.VariantListSize))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, v := range vv.ValueList() {
+			if v.Len() == 0 {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantValueListAtLenIter(b *testing.B) {
+	vv := NewValueList(createVariantStringSlice(testutil.VariantListSize))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < vv.Len(); j++ {
+			v := vv.ValueAt(j)
+			if v.Len() == 0 {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkVariantValueListAt(b *testing.B) {
+	vv := NewValueList(createVariantStringSlice(testutil.VariantListSize))
+	b.ResetTimer()
+	l := vv.Len()
+	j := 0
+	for i := 0; i < b.N; i++ {
+		v := vv.ValueAt(j)
+		if v.Len() == 0 {
+			panic("empty string")
+		}
+		j++
+		if j >= l {
+			j = 0
+		}
+	}
+}
+
+func BenchmarkVariantValueListLen(b *testing.B) {
+	vv := NewValueList(createVariantStringSlice(testutil.VariantListSize))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if vv.Len() < -i {
+			panic("empty string")
+		}
+	}
+}
+
+func BenchmarkStringFromBytes(b *testing.B) {
+	bytes := []byte{'a', 'b', 'c'}
+	for i := 0; i < b.N; i++ {
+		v := NewString(string(bytes))
+		str := v.StringVal()
+		if str != "abc" {
+			panic("invalid string")
+		}
+	}
+}
+
+func BenchmarkStringOptimizedFromBytes(b *testing.B) {
+	bytes := []byte{'a', 'b', 'c'}
+	for i := 0; i < b.N; i++ {
+		v := NewStringFromBytes(bytes)
+		str := v.StringVal()
+		if str != "abc" {
+			panic("invalid string")
+		}
+	}
+}
+
+func createStringSlice(n int) []string {
+	v := make([]string, n)
+	for i := 0; i < n; i++ {
+		v[i] = "abc"
+	}
+	return v
+}
+
+func BenchmarkNativeStringSliceGetAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vv := createStringSlice(testutil.VariantListSize)
+		for _, v := range vv {
+			if len(v) == 0 {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkNativeStringSliceForRangeAll(b *testing.B) {
+	vv := createStringSlice(testutil.VariantListSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, v := range vv {
+			if len(v) == 0 {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkNativeStringSliceAtLenIter(b *testing.B) {
+	vv := createStringSlice(testutil.VariantListSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(vv); j++ {
+			if len(vv[j]) == 0 {
+				panic("empty string")
+			}
+		}
+	}
+}
+
+func BenchmarkNativeStringSliceAt(b *testing.B) {
+	vv := createStringSlice(testutil.VariantListSize)
+	b.ResetTimer()
+	l := len(vv)
+	j := 0
+	for i := 0; i < b.N; i++ {
+		v := vv[j]
+		if len(v) == 0 {
+			panic("empty string")
+		}
+		j++
+		if j >= l {
+			j = 0
+		}
+	}
+}
+
+func BenchmarkNativeStringSliceLen(b *testing.B) {
+	vv := createStringSlice(testutil.VariantListSize)
+	for i := 0; i < b.N; i++ {
+		if len(vv) < -i {
+			panic("empty string")
+		}
+	}
+}

--- a/variant/doc.go
+++ b/variant/doc.go
@@ -27,9 +27,9 @@ type and read it. For example:
  }
 
 Variant uses an efficient data structure that is small and fast to operate on.
-On 64 bit systems the size of Variant is 24 bytes for scalar types (such as int or
-float64) plus any necessary additional data required by variable-sized types (String,
-List, etc).
+On 64 bit systems the size of Variant is 24 bytes for primitive types such as int or
+float64. For variable-sized types (String, List, etc) Variant stores a pointer to the
+data and length counter (similarly to how Go's built-in string and slice types do).
 
 To maximize the performance Variant functions do not return errors. All functions define
 clear contracts that describe in which case the calls are valid. In such cases it is


### PR DESCRIPTION
On 64 bis systems this implementation saves 8 bytes per Variant.