### PR TITLE
Rename VType to Type

### DIFF
--- a/internal/plainstruct/plainstruct.go
+++ b/internal/plainstruct/plainstruct.go
@@ -3,31 +3,31 @@ package plainstruct
 import "github.com/tigrannajaryan/govariant/variant"
 
 type Variant struct {
-	typ   variant.VType
+	typ   variant.Type
 	bytes []byte
 	str   string
 	i     int
 	f     float64
 }
 
-func (v *Variant) Type() variant.VType {
+func (v *Variant) Type() variant.Type {
 	return v.typ
 }
 
 func IntVariant(v int) Variant {
-	return Variant{typ: variant.VTypeInt, i: v}
+	return Variant{typ: variant.TypeInt, i: v}
 }
 
 func StringVariant(v string) Variant {
-	return Variant{typ: variant.VTypeString, str: v}
+	return Variant{typ: variant.TypeString, str: v}
 }
 
 func BytesVariant(v []byte) Variant {
-	return Variant{typ: variant.VTypeBytes, bytes: v}
+	return Variant{typ: variant.TypeBytes, bytes: v}
 }
 
 func Float64Variant(v float64) Variant {
-	return Variant{typ: variant.VTypeFloat64, f: v}
+	return Variant{typ: variant.TypeFloat64, f: v}
 }
 
 func (v *Variant) Int() int {

--- a/internal/plainstruct/plainstruct_test.go
+++ b/internal/plainstruct/plainstruct_test.go
@@ -18,25 +18,25 @@ func TestUVariant(t *testing.T) {
 	v := BytesVariant(b1)
 	b2 := v.Bytes()
 	assert.EqualValues(t, b1, b2)
-	assert.EqualValues(t, variant.VTypeBytes, v.Type())
+	assert.EqualValues(t, variant.TypeBytes, v.Type())
 
 	s1 := "abcdef"
 	v = StringVariant(s1)
 	s2 := v.String()
 	assert.EqualValues(t, s1, s2)
-	assert.EqualValues(t, variant.VTypeString, v.Type())
+	assert.EqualValues(t, variant.TypeString, v.Type())
 
 	i1 := 1234
 	v = IntVariant(i1)
 	i2 := v.Int()
 	assert.EqualValues(t, i1, i2)
-	assert.EqualValues(t, variant.VTypeInt, v.Type())
+	assert.EqualValues(t, variant.TypeInt, v.Type())
 
 	f1 := 1234.567
 	v = Float64Variant(f1)
 	f2 := v.Float64()
 	assert.EqualValues(t, f1, f2)
-	assert.EqualValues(t, variant.VTypeFloat64, v.Type())
+	assert.EqualValues(t, variant.TypeFloat64, v.Type())
 
 	//assert.EqualValues(t, 8, unsafe.Sizeof(int(123)))
 }
@@ -92,7 +92,7 @@ func BenchmarkVariantFloat64Get(b *testing.B) {
 func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantInt()
-		if v.Type() == variant.VTypeInt {
+		if v.Type() == variant.TypeInt {
 			vi := v.Int()
 			if vi != vi {
 				panic("invalid value")
@@ -106,7 +106,7 @@ func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantString()
-		if v.Type() == variant.VTypeString {
+		if v.Type() == variant.TypeString {
 			if v.String() == "" {
 				panic("empty string")
 			}
@@ -119,7 +119,7 @@ func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 func BenchmarkVariantBytesTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantBytes()
-		if v.Type() == variant.VTypeBytes {
+		if v.Type() == variant.TypeBytes {
 			if v.Bytes() == nil {
 				panic("nil bytes")
 			}
@@ -160,7 +160,7 @@ func BenchmarkVariantIntSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantIntSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == variant.VTypeInt {
+			if v.Type() == variant.TypeInt {
 				if v.Int() < 0 {
 					panic("zero int")
 				}
@@ -175,7 +175,7 @@ func BenchmarkVariantStringSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantStringSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == variant.VTypeString {
+			if v.Type() == variant.TypeString {
 				if v.String() == "" {
 					panic("empty string")
 				}

--- a/internal/ptrstruct/ptrstruct.go
+++ b/internal/ptrstruct/ptrstruct.go
@@ -3,31 +3,31 @@ package ptrstruct
 import "github.com/tigrannajaryan/govariant/variant"
 
 type Variant struct {
-	typ   variant.VType
+	typ   variant.Type
 	bytes []byte
 	str   string
 	i     int
 	f     float64
 }
 
-func (v *Variant) Type() variant.VType {
+func (v *Variant) Type() variant.Type {
 	return v.typ
 }
 
 func IntVariant(v int) *Variant {
-	return &Variant{typ: variant.VTypeInt, i: v}
+	return &Variant{typ: variant.TypeInt, i: v}
 }
 
 func StringVariant(v string) *Variant {
-	return &Variant{typ: variant.VTypeString, str: v}
+	return &Variant{typ: variant.TypeString, str: v}
 }
 
 func BytesVariant(v []byte) *Variant {
-	return &Variant{typ: variant.VTypeBytes, bytes: v}
+	return &Variant{typ: variant.TypeBytes, bytes: v}
 }
 
 func Float64Variant(v float64) *Variant {
-	return &Variant{typ: variant.VTypeFloat64, f: v}
+	return &Variant{typ: variant.TypeFloat64, f: v}
 }
 
 func (v *Variant) Int() int {

--- a/internal/ptrstruct/ptrstruct_test.go
+++ b/internal/ptrstruct/ptrstruct_test.go
@@ -18,25 +18,25 @@ func TestUVariant(t *testing.T) {
 	v := BytesVariant(b1)
 	b2 := v.Bytes()
 	assert.EqualValues(t, b1, b2)
-	assert.EqualValues(t, variant.VTypeBytes, v.Type())
+	assert.EqualValues(t, variant.TypeBytes, v.Type())
 
 	s1 := "abcdef"
 	v = StringVariant(s1)
 	s2 := v.String()
 	assert.EqualValues(t, s1, s2)
-	assert.EqualValues(t, variant.VTypeString, v.Type())
+	assert.EqualValues(t, variant.TypeString, v.Type())
 
 	i1 := 1234
 	v = IntVariant(i1)
 	i2 := v.Int()
 	assert.EqualValues(t, i1, i2)
-	assert.EqualValues(t, variant.VTypeInt, v.Type())
+	assert.EqualValues(t, variant.TypeInt, v.Type())
 
 	f1 := 1234.567
 	v = Float64Variant(f1)
 	f2 := v.Float64()
 	assert.EqualValues(t, f1, f2)
-	assert.EqualValues(t, variant.VTypeFloat64, v.Type())
+	assert.EqualValues(t, variant.TypeFloat64, v.Type())
 
 	//assert.EqualValues(t, 8, unsafe.Sizeof(int(123)))
 }
@@ -92,7 +92,7 @@ func BenchmarkVariantFloat64Get(b *testing.B) {
 func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantInt()
-		if v.Type() == variant.VTypeInt {
+		if v.Type() == variant.TypeInt {
 			vi := v.Int()
 			if vi != vi {
 				panic("invalid value")
@@ -106,7 +106,7 @@ func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantString()
-		if v.Type() == variant.VTypeString {
+		if v.Type() == variant.TypeString {
 			if v.String() == "" {
 				panic("empty string")
 			}
@@ -119,7 +119,7 @@ func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 func BenchmarkVariantBytesTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantBytes()
-		if v.Type() == variant.VTypeBytes {
+		if v.Type() == variant.TypeBytes {
 			if v.Bytes() == nil {
 				panic("nil bytes")
 			}
@@ -160,7 +160,7 @@ func BenchmarkVariantIntSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantIntSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == variant.VTypeInt {
+			if v.Type() == variant.TypeInt {
 				if v.Int() < 0 {
 					panic("zero int")
 				}
@@ -175,7 +175,7 @@ func BenchmarkVariantStringSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantStringSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == variant.VTypeString {
+			if v.Type() == variant.TypeString {
 				if v.String() == "" {
 					panic("empty string")
 				}

--- a/variant/doc.go
+++ b/variant/doc.go
@@ -24,7 +24,7 @@ To use a Variant first create and store a value in it. When the stored value
 is needed check the stored value type and read it. For example:
 
  v := variant.NewInt(123)
- if v.Type() == variant.VTypeInt {
+ if v.Type() == variant.TypeInt {
    x := v.IntVal() // x is now int value 123.
  }
 
@@ -40,7 +40,7 @@ in erroneous situation the functions will either return an undefined value or wi
 The documentation for each function will describe which of those two things will happen.
 
 If a list is stored in the Variant it uses panics to mimic the behavior of builtin Go
-slice type. For example accessing an element of a VTypeValueList using an index that is
+slice type. For example accessing an element of a TypeValueList using an index that is
 out of bounds will result in a panic.
 */
 package variant

--- a/variant/example_print_test.go
+++ b/variant/example_print_test.go
@@ -10,22 +10,22 @@ import (
 // variantToString converts a Variant to a human readable string.
 func variantToString(v variant.Variant) string {
 	switch v.Type() {
-	case variant.VTypeEmpty:
+	case variant.TypeEmpty:
 		return ""
 
-	case variant.VTypeInt:
+	case variant.TypeInt:
 		return fmt.Sprintf("%v", v.IntVal())
 
-	case variant.VTypeFloat64:
+	case variant.TypeFloat64:
 		return fmt.Sprintf("%v", v.Float64Val())
 
-	case variant.VTypeString:
+	case variant.TypeString:
 		return fmt.Sprintf("%q", v.StringVal())
 
-	case variant.VTypeBytes:
+	case variant.TypeBytes:
 		return fmt.Sprintf("0x%X", v.Bytes())
 
-	case variant.VTypeValueList:
+	case variant.TypeValueList:
 		sb := strings.Builder{}
 		sb.WriteString("[")
 		for i, e := range v.ValueList() {
@@ -37,7 +37,7 @@ func variantToString(v variant.Variant) string {
 		sb.WriteString("]")
 		return sb.String()
 
-	case variant.VTypeKeyValueList:
+	case variant.TypeKeyValueList:
 		sb := strings.Builder{}
 		sb.WriteString("{")
 		for i, kv := range v.KeyValueList() {

--- a/variant/example_test.go
+++ b/variant/example_test.go
@@ -8,7 +8,7 @@ import (
 
 func ExampleNewInt() {
 	v := variant.NewInt(123)
-	if v.Type() == variant.VTypeInt {
+	if v.Type() == variant.TypeInt {
 		fmt.Print(v.IntVal())
 	}
 

--- a/variant/variant_32.go
+++ b/variant/variant_32.go
@@ -23,22 +23,22 @@ type Variant struct {
 	capOrVal int64
 }
 
-// NewInt creates a Variant of VTypeInt type.
+// NewInt creates a Variant of TypeInt type.
 func NewInt(v int) Variant {
 	return Variant{
-		lenAndType: int(VTypeInt),
+		lenAndType: int(TypeInt),
 		capOrVal:   int64(v),
 	}
 }
 
-// NewFloat64 creates a Variant of VTypeFloat64 type.
+// NewFloat64 creates a Variant of TypeFloat64 type.
 func NewFloat64(v float64) (r Variant) {
-	r.lenAndType = int(VTypeFloat64)
+	r.lenAndType = int(TypeFloat64)
 	*(*float64)(unsafe.Pointer(&r.capOrVal)) = v
 	return r
 }
 
-// NewBytes creates a Variant of VTypeBytes type and initializes it with the specified
+// NewBytes creates a Variant of TypeBytes type and initializes it with the specified
 // slice of bytes.
 //
 // This function does not copy the slice. the Variant will point to
@@ -52,12 +52,12 @@ func NewBytes(v []byte) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeBytes),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeBytes),
 		capOrVal:   int64(hdr.Cap),
 	}
 }
 
-// NewValueList creates a Variant of VTypeValueList type and initializes it with the
+// NewValueList creates a Variant of TypeValueList type and initializes it with the
 // specified slice of Variants.
 //
 // This function does not copy the slice. The Variant will point to the same slice that
@@ -71,12 +71,12 @@ func NewValueList(v []Variant) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeValueList),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeValueList),
 		capOrVal:   int64(hdr.Cap),
 	}
 }
 
-// NewKeyValueList creates a Variant of VTypeKeyValueList type and initializes it with the
+// NewKeyValueList creates a Variant of TypeKeyValueList type and initializes it with the
 // specified slice of KeyValues.
 //
 // This function does not copy the slice. The Variant will point to the same slice that
@@ -87,7 +87,7 @@ func NewKeyValueList(v []KeyValue) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeKeyValueList),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeKeyValueList),
 		capOrVal:   int64(hdr.Cap),
 	}
 }

--- a/variant/variant_64.go
+++ b/variant/variant_64.go
@@ -9,10 +9,10 @@ import (
 	"unsafe"
 )
 
-// Variant allows to store values of one of the VType data types.
+// Variant allows to store values of one of the Type data types.
 //
 // To create a Variant use one of New* functions in this package. Note that
-// zero-initialized value of Variant is a valid VTypeEmpty value.
+// zero-initialized value of Variant is a valid TypeEmpty value.
 // To access the stored value call one of the *Val methods of Variant struct.
 type Variant struct {
 	// Pointer to the slice start for slice-based types.
@@ -28,23 +28,23 @@ type Variant struct {
 	capOrVal int
 }
 
-// NewInt creates a Variant of VTypeInt type.
+// NewInt creates a Variant of TypeInt type.
 func NewInt(v int) Variant {
 	return Variant{
-		lenAndType: int(VTypeInt),
+		lenAndType: int(TypeInt),
 		capOrVal:   v,
 	}
 }
 
-// NewFloat64 creates a Variant of VTypeFloat64 type.
+// NewFloat64 creates a Variant of TypeFloat64 type.
 func NewFloat64(v float64) Variant {
 	return Variant{
-		lenAndType: int(VTypeFloat64),
+		lenAndType: int(TypeFloat64),
 		capOrVal:   *(*int)(unsafe.Pointer(&v)),
 	}
 }
 
-// NewBytes creates a Variant of VTypeBytes type and initializes it with the specified
+// NewBytes creates a Variant of TypeBytes type and initializes it with the specified
 // slice of bytes.
 //
 // This function does not copy the slice. The Variant will point to
@@ -58,12 +58,12 @@ func NewBytes(v []byte) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeBytes),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeBytes),
 		capOrVal:   hdr.Cap,
 	}
 }
 
-// NewValueList creates a Variant of VTypeValueList type and initializes it with the
+// NewValueList creates a Variant of TypeValueList type and initializes it with the
 // specified slice of Variants.
 //
 // This function does not copy the slice. The Variant will point to the same slice that
@@ -77,12 +77,12 @@ func NewValueList(v []Variant) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeValueList),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeValueList),
 		capOrVal:   hdr.Cap,
 	}
 }
 
-// NewKeyValueList creates a Variant of VTypeKeyValueList type and initializes it with the
+// NewKeyValueList creates a Variant of TypeKeyValueList type and initializes it with the
 // specified slice of KeyValues.
 //
 // This function does not copy the slice. The Variant will point to the same slice that
@@ -93,7 +93,7 @@ func NewKeyValueList(v []KeyValue) Variant {
 
 	return Variant{
 		ptr:        unsafe.Pointer(hdr.Data),
-		lenAndType: (hdr.Len << typeFieldBitCount) | int(VTypeKeyValueList),
+		lenAndType: (hdr.Len << typeFieldBitCount) | int(TypeKeyValueList),
 		capOrVal:   hdr.Cap,
 	}
 }

--- a/variant/variant_test.go
+++ b/variant/variant_test.go
@@ -43,41 +43,41 @@ func TestVariant(t *testing.T) {
 	fmt.Printf("Variant size=%v bytes\n", unsafe.Sizeof(Variant{}))
 
 	v := NewEmpty()
-	assert.EqualValues(t, VTypeEmpty, v.Type())
+	assert.EqualValues(t, TypeEmpty, v.Type())
 	assert.EqualValues(t, "", v.String())
 
 	b1 := []byte{1, 2, 0xA}
 	v = NewBytes(b1)
 	b2 := v.Bytes()
 	assert.EqualValues(t, b1, b2)
-	assert.EqualValues(t, VTypeBytes, v.Type())
+	assert.EqualValues(t, TypeBytes, v.Type())
 	assert.EqualValues(t, "0x01020A", v.String())
 
 	s1 := "abcdef"
 	v = NewString(s1)
 	s2 := v.StringVal()
 	assert.EqualValues(t, s1, s2)
-	assert.EqualValues(t, VTypeString, v.Type())
+	assert.EqualValues(t, TypeString, v.Type())
 	assert.EqualValues(t, `"abcdef"`, v.String())
 
 	i1 := 1234
 	v = NewInt(i1)
 	i2 := v.IntVal()
 	assert.EqualValues(t, i1, i2)
-	assert.EqualValues(t, VTypeInt, v.Type())
+	assert.EqualValues(t, TypeInt, v.Type())
 	assert.EqualValues(t, "1234", v.String())
 
 	f1 := 1234.567
 	v = NewFloat64(f1)
 	f2 := v.Float64Val()
 	assert.EqualValues(t, f1, f2)
-	assert.EqualValues(t, VTypeFloat64, v.Type())
+	assert.EqualValues(t, TypeFloat64, v.Type())
 	assert.EqualValues(t, "1234.567", v.String())
 }
 
 func TestVariantValueList(t *testing.T) {
 	v := NewValueList(nil)
-	assert.EqualValues(t, VTypeValueList, v.Type())
+	assert.EqualValues(t, TypeValueList, v.Type())
 	assert.EqualValues(t, 0, v.Len())
 	assert.EqualValues(t, []Variant(nil), v.ValueList())
 	assert.EqualValues(t, "[]", v.String())
@@ -96,7 +96,7 @@ func TestVariantValueList(t *testing.T) {
 func TestVariantKeyValueList(t *testing.T) {
 	var nilKvl []KeyValue
 	v := NewKeyValueList(nilKvl)
-	assert.EqualValues(t, VTypeKeyValueList, v.Type())
+	assert.EqualValues(t, TypeKeyValueList, v.Type())
 	assert.EqualValues(t, 0, v.Len())
 	assert.EqualValues(t, nilKvl, v.KeyValueList())
 	assert.EqualValues(t, "{}", v.String())
@@ -276,7 +276,7 @@ func BenchmarkVariantFloat64Get(b *testing.B) {
 func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantInt()
-		if v.Type() == VTypeInt {
+		if v.Type() == TypeInt {
 			vi := v.IntVal()
 			if vi != testutil.IntMagicVal {
 				panic("invalid value")
@@ -290,7 +290,7 @@ func BenchmarkVariantIntTypeAndGet(b *testing.B) {
 func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantString()
-		if v.Type() == VTypeString {
+		if v.Type() == TypeString {
 			if v.StringVal() == "" {
 				panic("empty string")
 			}
@@ -303,7 +303,7 @@ func BenchmarkVariantStringTypeAndGet(b *testing.B) {
 func BenchmarkVariantBytesTypeAndGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		v := createVariantBytes()
-		if v.Type() == VTypeBytes {
+		if v.Type() == TypeBytes {
 			if v.Bytes() == nil {
 				panic("nil bytes")
 			}
@@ -344,7 +344,7 @@ func BenchmarkVariantIntSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantIntSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == VTypeInt {
+			if v.Type() == TypeInt {
 				if v.IntVal() < 0 {
 					panic("zero int")
 				}
@@ -359,7 +359,7 @@ func BenchmarkVariantStringSliceTypeAndGetAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		vv := createVariantStringSlice(testutil.VariantListSize)
 		for _, v := range vv {
-			if v.Type() == VTypeString {
+			if v.Type() == TypeString {
 				if v.StringVal() == "" {
 					panic("empty string")
 				}


### PR DESCRIPTION
V prefix was unnecessary. Remove for cleaner names